### PR TITLE
feat: org-wide reusable workflows + community health + shared renovate preset

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers of the MCA-NITW organisation pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Using welcoming and inclusive language.
+- Being respectful of differing viewpoints and experiences.
+- Gracefully accepting constructive feedback.
+- Focusing on what is best for the community.
+- Showing empathy toward other community members.
+
+Examples of unacceptable behaviour:
+
+- Trolling, insulting/derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information without explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the org admins via private channels. All complaints will be reviewed and investigated promptly and fairly.
+
+Maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the org's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to MCA-NITW
+
+Thanks for taking the time to contribute! This file is auto-applied to every MCA-NITW repo that doesn't have its own `CONTRIBUTING.md`. Each repo may add a more specific guide on top of this baseline.
+
+## Quick start
+
+1. **Fork the repo** and clone your fork.
+2. **Create a feature branch** from `main`: `git checkout -b feat/short-description`.
+3. **Install dependencies** (most of our repos use `pnpm` — see the repo's README for stack-specific commands).
+4. **Make your change** with a focused commit history.
+5. **Push and open a PR** against `main`. Bots will run lint, build, and security scans automatically.
+
+## Branch and commit conventions
+
+- **Branch names:** `feat/...`, `fix/...`, `chore/...`, `docs/...`, `refactor/...`, `test/...`.
+- **Commit messages:** Conventional Commits — `feat:`, `fix:`, `chore:`, etc. Keep the subject under 70 chars; use the body for context.
+- **One PR per logical change.** Don't bundle a refactor with a feature in the same PR.
+- **Never force-push to `main`.** Feature branches you own are fine to force-push (with `--force-with-lease`).
+
+## What our CI checks
+
+Every PR runs reusable workflows from `mca-nitw/.github`:
+
+- **`node-ci`** — install / lint / build / test (auto-detects pnpm vs npm).
+- **`format-check`** — Prettier formatting (`npx prettier --check .`).
+- **`security-scan`** — Trivy filesystem scan + GitHub Dependency Review (fails on high-severity vulns).
+- **CodeQL** (per repo where applicable) — static analysis.
+- **SonarCloud** (per repo where configured) — quality gate.
+
+## Renovate
+
+Dependency updates are managed by **Renovate**:
+
+- Non-major weekly updates are grouped and auto-merged when CI passes (Mondays at 03:00 IST).
+- Security advisories trigger immediate PRs and bypass the weekly schedule.
+- Major bumps require manual approval from the dependency dashboard.
+- The shared config lives in `mca-nitw/.github/renovate.json5` — repos extend it via `"extends": ["github>mca-nitw/.github"]`.
+
+## Reporting issues
+
+- **Security vulnerabilities:** see [SECURITY.md](SECURITY.md). Do not open public issues for vulns.
+- **Bugs / feature requests:** open an issue in the relevant repo with a clear repro or use-case.
+- **Want to join the org?** Open a `[Join Request]` issue in [`mca-nitw/.github`](https://github.com/MCA-NITW/.github/issues/new/choose) — automated invites trigger from there.
+
+## Code of Conduct
+
+By participating you agree to our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- One or two sentences on what this PR does and why. -->
+
+## Type of change
+
+<!-- Check what applies. -->
+
+- [ ] feat — new feature
+- [ ] fix — bug fix
+- [ ] chore — tooling, dependencies, refactor with no behaviour change
+- [ ] docs — documentation only
+- [ ] test — tests only
+- [ ] ci — CI or workflow change
+- [ ] refactor — code restructure with no behaviour change
+
+## Checklist
+
+- [ ] I read [CONTRIBUTING.md](https://github.com/MCA-NITW/.github/blob/main/.github/CONTRIBUTING.md).
+- [ ] My branch follows the naming convention (`feat/...`, `fix/...`, `chore/...`).
+- [ ] My commits use Conventional Commits format.
+- [ ] I ran `pnpm run build` (or stack equivalent) locally and it passes.
+- [ ] I ran `npx prettier --check .` and it passes (or my changes don't touch tracked files).
+- [ ] I added or updated tests for behaviour changes.
+- [ ] I updated docs (README, CHANGELOG, or relevant `.md`) if user-visible behaviour changed.
+
+## Screenshots / logs
+
+<!-- Optional. Drop screenshots, terminal output, or before/after diffs that help reviewers. -->
+
+## Related issues
+
+<!-- "Closes #123", "Relates to #456" -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+This policy applies to **all repositories under the [`mca-nitw`](https://github.com/MCA-NITW) organisation**. Individual repos may add a stricter `SECURITY.md` on top of this baseline.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Instead, use one of:
+
+1. **Private vulnerability reporting** on the affected repo — go to *Security → Report a vulnerability* (this is the preferred channel).
+2. **Email** the org admins listed in the org profile.
+
+Include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (proof of concept welcome).
+- Affected versions / commit SHAs.
+- Suggested fix if you have one.
+
+We aim to acknowledge within **3 working days** and resolve / mitigate within **30 days** for critical issues.
+
+## Scope
+
+In scope:
+
+- Source code in any public `mca-nitw/*` repo.
+- Deployment configurations and infrastructure-as-code committed to those repos.
+- The org's automation workflows under `mca-nitw/.github`.
+
+Out of scope:
+
+- Third-party dependencies (report upstream — we'll prioritise mitigations once disclosed).
+- Social-engineering attacks against members.
+- Volumetric DoS testing against any deployed app.
+
+## Supported versions
+
+The latest commit on `main` of each repo is supported. Older tags receive security fixes only on a best-effort basis.
+
+## Recognition
+
+We don't currently run a paid bug-bounty programme, but we're happy to credit reporters in release notes or PR descriptions on request.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Org-wide Dependabot config — bumps GitHub Actions in our reusable workflows.
+# Renovate handles npm/pnpm/Docker/etc, so this only covers the actions ecosystem
+# inside this repo.
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(actions)"
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,65 @@
+name: Reusable Format Check
+
+# Runs Prettier --check across the repo.
+# Honours .prettierignore in the consumer repo.
+#
+# Usage:
+#   jobs:
+#     format:
+#       uses: mca-nitw/.github/.github/workflows/format-check.yml@main
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: Node.js version
+        required: false
+        type: string
+        default: "22.x"
+      glob:
+        description: Files/dirs prettier should check
+        required: false
+        type: string
+        default: "."
+
+jobs:
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Detect package manager
+        id: pm
+        shell: bash
+        run: |
+          if [ -f "pnpm-lock.yaml" ]; then
+            echo "manager=pnpm" >> "$GITHUB_OUTPUT"
+          elif [ -f "yarn.lock" ]; then
+            echo "manager=yarn" >> "$GITHUB_OUTPUT"
+          else
+            echo "manager=npm" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup pnpm
+        if: steps.pm.outputs.manager == 'pnpm'
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ steps.pm.outputs.manager }}
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          case "${{ steps.pm.outputs.manager }}" in
+            pnpm) pnpm install --frozen-lockfile ;;
+            yarn) yarn install --frozen-lockfile ;;
+            npm)  npm ci ;;
+          esac
+
+      - name: Run Prettier check
+        run: npx prettier --check ${{ inputs.glob }}

--- a/.github/workflows/markdown-check.yml
+++ b/.github/workflows/markdown-check.yml
@@ -1,0 +1,56 @@
+name: Reusable Markdown Check
+
+# For docs-only repos (Academic, etc).
+# - Lints Markdown with markdownlint
+# - Checks dead links with lychee
+#
+# Usage:
+#   jobs:
+#     docs:
+#       uses: mca-nitw/.github/.github/workflows/markdown-check.yml@main
+
+on:
+  workflow_call:
+    inputs:
+      glob:
+        description: Files markdownlint should check
+        required: false
+        type: string
+        default: "**/*.md"
+      check-links:
+        description: Whether to run lychee dead-link check
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  markdownlint:
+    name: Markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v20
+        with:
+          globs: ${{ inputs.glob }}
+        continue-on-error: true
+
+  lychee:
+    name: Dead-link check
+    runs-on: ubuntu-latest
+    if: inputs.check-links
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@1d97373ee35d3bed0f1d249ac37f5e6cad11fb89 # v2
+        with:
+          args: --no-progress --max-concurrency 4 --exclude-mail .
+          fail: false

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,126 @@
+name: Reusable Node CI
+
+# Auto-detects pnpm vs npm based on lockfile.
+# Runs install, build, test (if present), lint (if present).
+#
+# Usage from a consumer repo:
+#   jobs:
+#     ci:
+#       uses: mca-nitw/.github/.github/workflows/node-ci.yml@main
+#       with:
+#         node-version: "22.x"
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: Node.js version (e.g. "22.x")
+        required: false
+        type: string
+        default: "22.x"
+      run-tests:
+        description: Whether to run tests after build
+        required: false
+        type: boolean
+        default: true
+      run-lint:
+        description: Whether to run lint script if present
+        required: false
+        type: boolean
+        default: true
+      build-script:
+        description: npm/pnpm script to run for build
+        required: false
+        type: string
+        default: build
+      working-directory:
+        description: Run all commands inside this directory
+        required: false
+        type: string
+        default: "."
+
+jobs:
+  ci:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Detect package manager
+        id: pm
+        shell: bash
+        run: |
+          cd "${{ inputs.working-directory }}"
+          if [ -f "pnpm-lock.yaml" ]; then
+            echo "manager=pnpm" >> "$GITHUB_OUTPUT"
+          elif [ -f "yarn.lock" ]; then
+            echo "manager=yarn" >> "$GITHUB_OUTPUT"
+          else
+            echo "manager=npm" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Detected: $(cat $GITHUB_OUTPUT | grep manager= | cut -d= -f2)"
+
+      - name: Setup pnpm
+        if: steps.pm.outputs.manager == 'pnpm'
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
+
+      - name: Setup Node.js ${{ inputs.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ steps.pm.outputs.manager }}
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          case "${{ steps.pm.outputs.manager }}" in
+            pnpm) pnpm install --frozen-lockfile ;;
+            yarn) yarn install --frozen-lockfile ;;
+            npm)  npm ci ;;
+          esac
+
+      - name: Lint (if script exists)
+        if: inputs.run-lint
+        shell: bash
+        run: |
+          if grep -q '"lint"' package.json; then
+            case "${{ steps.pm.outputs.manager }}" in
+              pnpm) pnpm run lint ;;
+              yarn) yarn lint ;;
+              npm)  npm run lint ;;
+            esac
+          else
+            echo "No lint script defined — skipping."
+          fi
+
+      - name: Build (${{ inputs.build-script }})
+        shell: bash
+        run: |
+          if grep -q "\"${{ inputs.build-script }}\"" package.json; then
+            case "${{ steps.pm.outputs.manager }}" in
+              pnpm) pnpm run ${{ inputs.build-script }} ;;
+              yarn) yarn ${{ inputs.build-script }} ;;
+              npm)  npm run ${{ inputs.build-script }} ;;
+            esac
+          else
+            echo "No ${{ inputs.build-script }} script defined — skipping."
+          fi
+
+      - name: Test (if script exists)
+        if: inputs.run-tests
+        shell: bash
+        run: |
+          if grep -q '"test"' package.json; then
+            case "${{ steps.pm.outputs.manager }}" in
+              pnpm) pnpm test ;;
+              yarn) yarn test ;;
+              npm)  npm test ;;
+            esac
+          else
+            echo "No test script defined — skipping."
+          fi

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,69 @@
+name: Reusable Security Scan
+
+# Runs security tooling that should apply uniformly to every repo:
+# - Dependency Review (PRs only) — fails on high-severity vulns
+# - Trivy filesystem scan (uploads SARIF to Code Scanning tab)
+#
+# Usage:
+#   jobs:
+#     security:
+#       uses: mca-nitw/.github/.github/workflows/security-scan.yml@main
+
+on:
+  workflow_call:
+    inputs:
+      fail-on-severity:
+        description: Block PR on dependencies with this severity or higher
+        required: false
+        type: string
+        default: high
+      trivy-severity:
+        description: Comma-separated severities Trivy should report
+        required: false
+        type: string
+        default: CRITICAL,HIGH
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: ${{ inputs.fail-on-severity }}
+          allow-licenses: GPL-3.0, MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, CC-BY-4.0, CC0-1.0, Unlicense
+
+  trivy:
+    name: Trivy filesystem scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          severity: ${{ inputs.trivy-severity }}
+
+      - name: Upload Trivy SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy

--- a/renovate.json
+++ b/renovate.json
@@ -1,40 +1,41 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard"],
-  "timezone": "Asia/Kolkata",
-  "schedule": ["before 3am on monday"],
-  "prHourlyLimit": 2,
-  "prConcurrentLimit": 3,
-  "rangeStrategy": "replace",
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "groupName": "non-major weekly",
-      "labels": ["dependencies", "auto-merge"]
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "groupName": "major updates",
-      "labels": ["dependencies", "major"],
-      "dependencyDashboardApproval": true
-    },
-    {
-      "matchDatasources": ["docker"],
-      "groupName": "docker",
-      "schedule": ["before 3am on monday"]
-    },
-    {
-      "matchCategories": ["lock-file-maintenance"],
-      "schedule": ["before 3am on monday"],
-      "automerge": true
-    }
-  ],
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "labels": ["security"],
-    "schedule": ["at any time"]
-  }
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"description": "Shared MCA-NITW Renovate preset. Repos extend via 'extends': ['github>mca-nitw/.github']",
+	"extends": ["config:recommended", ":dependencyDashboard"],
+	"timezone": "Asia/Kolkata",
+	"schedule": ["before 3am on monday"],
+	"prHourlyLimit": 2,
+	"prConcurrentLimit": 3,
+	"rangeStrategy": "replace",
+	"packageRules": [
+		{
+			"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+			"automerge": true,
+			"automergeType": "pr",
+			"automergeStrategy": "squash",
+			"groupName": "non-major weekly",
+			"labels": ["dependencies", "auto-merge"]
+		},
+		{
+			"matchUpdateTypes": ["major"],
+			"groupName": "major updates",
+			"labels": ["dependencies", "major"],
+			"dependencyDashboardApproval": true
+		},
+		{
+			"matchDatasources": ["docker"],
+			"groupName": "docker",
+			"schedule": ["before 3am on monday"]
+		},
+		{
+			"matchCategories": ["lock-file-maintenance"],
+			"schedule": ["before 3am on monday"],
+			"automerge": true
+		}
+	],
+	"vulnerabilityAlerts": {
+		"enabled": true,
+		"labels": ["security"],
+		"schedule": ["at any time"]
+	}
 }


### PR DESCRIPTION
## Why

Currently every repo in the org reinvents CI:
- `placemento` has 6 workflows (~600 lines)
- `mca_nitw` has 250 lines of inline JS for auto-merge that duplicates Renovate's built-in feature
- `leetcode_among_us` and `Academic` have **zero CI**
- All 6 repos have an identical 1095-byte `renovate.json` copy-pasted

When a workflow needs fixing (like the npm->pnpm migration we just shipped on placemento), it has to be done N times.

## What this PR adds

### Reusable workflows (.github/workflows/)

| File | Purpose |
|---|---|
| `node-ci.yml` | Auto-detects pnpm/npm/yarn from lockfile; runs install + lint + build + test |
| `security-scan.yml` | Dependency Review + Trivy SARIF upload |
| `format-check.yml` | Prettier --check (honours .prettierignore in consumer) |
| `markdown-check.yml` | markdownlint + lychee dead-link check (for docs repos) |

### Community health (.github/)

| File | Auto-applies to |
|---|---|
| `CONTRIBUTING.md` | Every repo without its own |
| `SECURITY.md` | Every repo without its own |
| `CODE_OF_CONDUCT.md` | Every repo without its own |
| `PULL_REQUEST_TEMPLATE.md` | Every repo without its own |

### Org-level config

- `dependabot.yml` — weekly bump of github-actions used in our reusables
- `renovate.json` — turned into a **shared preset**. Consumer renovate.json drops to `{ extends: [github>mca-nitw/.github] }`

## Follow-up PRs (one per consumer repo)

After this lands I'll open thin PRs to:
1. **`placemento`** — replace 6 workflows with a single caller; reduce renovate.json to 1 line
2. **`mca_nitw`** — delete broken `check.yml` (yarn-on-non-yarn-repo) + 250-line `auto-merge-bots.yml` (Renovate handles it natively)
3. **`leetcode_among_us`** — add CI from scratch (it has none)
4. **`Academic`** — add markdown-check from scratch

Total: ~600 lines of YAML deleted across the org, replaced with ~150 lines of reusable workflows.