### PR TITLE
chore: consolidate all bot updates into one monthly PR (25th)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,41 +1,33 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"description": "Shared MCA-NITW Renovate preset. Repos extend via 'extends': ['github>mca-nitw/.github']",
+	"description": "Shared MCA-NITW Renovate preset. One grouped PR per repo, monthly on the 25th, auto-merged when CI is green. Repos extend via 'extends': ['github>mca-nitw/.github']",
 	"extends": ["config:recommended", ":dependencyDashboard"],
 	"timezone": "Asia/Kolkata",
-	"schedule": ["before 3am on monday"],
-	"prHourlyLimit": 2,
-	"prConcurrentLimit": 3,
+	"schedule": ["before 5am on the 25th day of the month"],
+	"prCreation": "immediate",
+	"prConcurrentLimit": 0,
+	"prHourlyLimit": 0,
 	"rangeStrategy": "replace",
+	"lockFileMaintenance": {
+		"enabled": true,
+		"schedule": ["before 5am on the 25th day of the month"]
+	},
 	"packageRules": [
 		{
-			"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+			"groupName": "monthly dependencies",
+			"groupSlug": "monthly",
+			"schedule": ["before 5am on the 25th day of the month"],
 			"automerge": true,
 			"automergeType": "pr",
 			"automergeStrategy": "squash",
-			"groupName": "non-major weekly",
 			"labels": ["dependencies", "auto-merge"]
-		},
-		{
-			"matchUpdateTypes": ["major"],
-			"groupName": "major updates",
-			"labels": ["dependencies", "major"],
-			"dependencyDashboardApproval": true
-		},
-		{
-			"matchDatasources": ["docker"],
-			"groupName": "docker",
-			"schedule": ["before 3am on monday"]
-		},
-		{
-			"matchCategories": ["lock-file-maintenance"],
-			"schedule": ["before 3am on monday"],
-			"automerge": true
 		}
 	],
 	"vulnerabilityAlerts": {
 		"enabled": true,
-		"labels": ["security"],
-		"schedule": ["at any time"]
+		"groupName": "monthly dependencies",
+		"groupSlug": "monthly",
+		"schedule": ["before 5am on the 25th day of the month"],
+		"labels": ["dependencies", "security"]
 	}
 }


### PR DESCRIPTION
Rewrites the shared MCA-NITW Renovate preset so every org repo (Academic, leetcode_among_us, mca_nitw, placemento) gets **one grouped dependency PR per month on the 25th**, auto-merged when CI is green, instead of scattered per-type/weekly PRs. Mirrors the Sagargupta16/shared-workflows policy. Single edit, org-wide effect.