### PR TITLE
chore(ci): allow MPL-2.0 and JSON in dependency review

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,10 @@ jobs:
         uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: ${{ inputs.fail-on-severity }}
-          allow-licenses: GPL-3.0, MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, CC-BY-4.0, CC0-1.0, Unlicense
+          # MPL-2.0 is file-level weak copyleft and carries no obligation for a
+          # dependency we consume unmodified; vite pulls in lightningcss under it.
+          # JSON covers recharts' victory-vendor (ISC AND JSON AND MIT).
+          allow-licenses: GPL-3.0, MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, CC-BY-4.0, CC0-1.0, Unlicense, MPL-2.0, JSON
 
   trivy:
     name: Trivy filesystem scan


### PR DESCRIPTION
## Problem

Dependency Review fails on every vite or recharts bump across org repos, even when the PR introduces zero vulnerabilities.

Two transitive packages are not covered by the allow-list:

- `lightningcss` (+ 11 platform binaries) is MPL-2.0, pulled in by `vite`
- `victory-vendor` is `ISC AND JSON AND MIT`, pulled in by `recharts`

Currently blocking `placemento#416` and `leetcode_among_us#171`, both of which pass every other check.

## Change

Adds `MPL-2.0` and `JSON` to `allow-licenses`.

MPL-2.0 is file-level weak copyleft. It obliges us only if we modify and distribute the covered files; consuming an unmodified dependency triggers nothing. vite ships it in its own default toolchain.

## Scope

`fail-on-severity` is untouched, so vulnerability gating is unchanged.